### PR TITLE
Deploy Socket.IO server to Fly.io and fix production connection timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Supabase Configuration
 VITE_SUPABASE_URL=your_supabase_url_here
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
+
+# Socket.IO Server Configuration
+VITE_SOCKET_SERVER_URL=http://localhost:3001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use Node.js 18 LTS
+FROM node:18-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci --only=production
+
+# Copy server source code
+COPY server/ ./server/
+
+# Expose port
+EXPOSE 8080
+
+# Start the server
+CMD ["node", "--loader", "tsx/esm", "server/index.ts"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,28 @@
+# fly.toml app configuration file generated for flyte-socket-server on 2025-07-02T23:48:36Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'flyte-socket-server'
+primary_region = 'iad'
+
+[build]
+
+[env]
+  PORT = '8080'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+
+[deploy]
+  strategy = 'immediate'

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,10 @@ const supabase = createClient(
 // Configure Socket.IO with CORS
 const io = new Server(server, {
   cors: {
-    origin: "http://localhost:5173",
+    origin: [
+      "http://localhost:5173",
+      "https://flyteapp.netlify.app"
+    ],
     methods: ["GET", "POST"],
     credentials: true
   }
@@ -364,7 +367,7 @@ app.get('/health', (req, res) => {
   })
 })
 
-const PORT = process.env.PORT || 3001
+const PORT = process.env.PORT || 8080
 
 server.listen(PORT, () => {
   console.log(`🚀 Socket.IO server running on port ${PORT}`)

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -34,7 +34,7 @@ class SocketManager {
   private maxReconnectAttempts = 5
   private reconnectDelay = 1000
 
-  connect(serverUrl: string = 'http://localhost:3001'): Socket {
+  connect(serverUrl: string = import.meta.env.VITE_SOCKET_SERVER_URL || 'http://localhost:3001'): Socket {
     if (this.socket?.connected) {
       return this.socket
     }


### PR DESCRIPTION
- Add Fly.io deployment configuration (fly.toml, Dockerfile)
- Update server CORS to allow production Netlify domain (https://flyteapp.netlify.app)
- Change server port from 3001 to 8080 for Fly.io compatibility
- Update client to use VITE_SOCKET_SERVER_URL environment variable instead of hardcoded localhost:3001
- Add Socket.IO server URL configuration to .env.example
- Deploy server to https://flyte-socket-server.fly.dev/

Fixes production connection timeout issue where users get stuck after login.